### PR TITLE
Fix double quotes causing crash

### DIFF
--- a/api.py
+++ b/api.py
@@ -780,7 +780,7 @@ def get_ansible_hosts():
             for idx, host in enumerate(pop.get("hosts")):
                 _config["all"]["children"]["hypervisors"]["hosts"][pop["name"] + str(idx)] = {
                     "ansible_host": host["ip"],
-                    "wgip": f"fd0d:944c:1337:aa64:{host["prefix"].split(":")[2]}::/80",
+                    "wgip": f"fd0d:944c:1337:aa64:{host['prefix'].split(':')[2]}::/80",
                     "bcg": {
                         "asn": config_doc["asn"],
                         "prefixes": [host["prefix"]],


### PR DESCRIPTION
```
May 23 15:20:39 portal gunicorn[1475]:   File "/home/api/api.py", line 783
May 23 15:20:39 portal gunicorn[1475]:     "wgip": f"fd0d:944c:1337:aa64:{host["prefix"].split(":")[2]}::/80",
May 23 15:20:39 portal gunicorn[1475]:                                               ^
May 23 15:20:39 portal gunicorn[1475]: SyntaxError: invalid syntax
```
This should fix that