### PR TITLE
Remove prefix from wgip variable so that it can be used elsewhere

### DIFF
--- a/api.py
+++ b/api.py
@@ -780,7 +780,7 @@ def get_ansible_hosts():
             for idx, host in enumerate(pop.get("hosts")):
                 _config["all"]["children"]["hypervisors"]["hosts"][pop["name"] + str(idx)] = {
                     "ansible_host": host["ip"],
-                    "wgip": f"fd0d:944c:1337:aa64:{host['prefix'].split(':')[2]}::/80",
+                    "wgip": f"fd0d:944c:1337:aa64:{host['prefix'].split(':')[2]}::",
                     "bcg": {
                         "asn": config_doc["asn"],
                         "prefixes": [host["prefix"]],

--- a/provisioning/roles/wg/tasks/main.yml
+++ b/provisioning/roles/wg/tasks/main.yml
@@ -95,7 +95,7 @@
   when: ipv6_vpn_hosts_present is not changed
   lineinfile:
     path: /etc/hosts
-    line: "{{ wgip | regex_replace('.{3}$','') }} {{ fqdn.stdout }} {{ hostname.stdout }}"
+    line: "{{ wgip }} {{ fqdn.stdout }} {{ hostname.stdout }}"
 
 - name: show pubkey
   debug:

--- a/provisioning/templates/client.conf.j2
+++ b/provisioning/templates/client.conf.j2
@@ -1,5 +1,5 @@
 [Interface]
-Address = {{ wgip }}
+Address = {{ wgip }}/80
 PrivateKey = {{ privkey.content | b64decode | trim }}
 
 [Peer]


### PR DESCRIPTION
Currently the libvirtd listening change is failing because the wgip includes that it is a /80, this should be removed from the `wgip` variable, and then just added back in using the wireguard config.