### PR TITLE
FF 77 and before support

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -10,7 +10,7 @@
 	import Dashboard from "./Dashboard.svelte";
 	import NotFound from "./pages/NotFound.svelte";
 	import MDPWrapper from "rollup-plugin-mdsvex-pages/src/components/MDPWrapper.svelte";
-import Snackbar from "./components/Snackbar.svelte";
+	import Snackbar from "./components/Snackbar.svelte";
 
 	const dashboardWrap = wrap({
 		component: Dashboard,
@@ -30,13 +30,15 @@ import Snackbar from "./components/Snackbar.svelte";
 		"*": NotFound,
 	};
 
+	let updateInterval = null;
+
 	function updateProjects(){
 		getUserProjects()
 		.then((data) => {
 			$Projects = data;
 		})
-		if ($User !== {}){
-			setTimeout(updateProjects, 15000)
+		if ($User !== {} && updateInterval == null){
+			updateInterval = setInterval(updateProjects, 15000)
 		}
 	}
 

--- a/frontend/src/components/Button.svelte
+++ b/frontend/src/components/Button.svelte
@@ -76,6 +76,7 @@
   button:active {
     background-color: #252424;
     border-color: #252424;
+    padding: 0rem 1.5rem;
   }
 
   button.outlined {

--- a/frontend/src/components/PageHeader.svelte
+++ b/frontend/src/components/PageHeader.svelte
@@ -23,9 +23,9 @@
 			<div class="button-wrapper">
 				{#each labels as label, i}
 					<button
-						class:current={params.page == label.toLowerCase().replaceAll(' ', '') || (i == 0 && params.page == null)}
+						class:current={params.page == label.toLowerCase().replace(/ /g, '') || (i == 0 && params.page == null)}
 						on:click={() => {
-							window.location.href = baseHref + "/" + label.toLowerCase().replaceAll(' ', '');
+							window.location.href = baseHref + "/" + label.toLowerCase().replace(/ /g, '');
 						}}>{label}</button>
 				{/each}
 			</div>

--- a/frontend/src/components/PageHeader.svelte
+++ b/frontend/src/components/PageHeader.svelte
@@ -89,14 +89,11 @@
 		margin: 0px;
 		margin-bottom: -5px;
 		cursor: pointer;
+		padding: 0px 8px;
 	}
 
 	button.current {
 		border-bottom: 5px solid #0e0d0d;
-	}
-
-	button:active {
-		padding: 0px 8px;
 	}
 
 	div.header {

--- a/frontend/src/pages/Create.svelte
+++ b/frontend/src/pages/Create.svelte
@@ -341,6 +341,7 @@
         background-color: #0e0d0d;
         border: none;
         height: 40px;
+        width: 40px;
         cursor: pointer;
     }
 


### PR DESCRIPTION
Turns out .replaceAll() was only implemented after Firefox 77, and Sayan happened to like using 75. This should fix that (at least with my testing on BrowserStack. Also apparently a few of my other commits snuck in here, so I will leave this for review until someone else merges it.