### PR TITLE
Rotate API key on password reset

### DIFF
--- a/api.py
+++ b/api.py
@@ -400,7 +400,7 @@ def user_login(json_body: dict) -> Response:
         if not valid:
             raise VerifyMismatchError
         else:
-            rsp = make_response(_resp(True, "Authentication successful"))
+            rsp = make_response(_resp(True, "Authentication successful", data = { "key": user["key"] }))
             # Set the API key cookie with a 90 day expiration date
             rsp.set_cookie("key", user["key"], httponly=True, secure=True, expires=datetime.datetime.now() + datetime.timedelta(days=90))
             return rsp

--- a/api.py
+++ b/api.py
@@ -378,7 +378,7 @@ def password_reset(json_body: dict) -> Response:
     if not json_body.get("password"):
         return _resp(False, "Password must exist")
 
-    db["users"].update_one({"email": user["email"]}, {"$set": {"password": argon.hash(json_body["password"])}, "$unset": {"password_reset_token": ""}})
+    db["users"].update_one({"email": user["email"]}, {"$set": {"password": argon.hash(json_body["password"]), "key": token_hex(24)}, "$unset": {"password_reset_token": ""}})
     add_audit_entry("user.password_reset", "", user["_id"], "", "")
     return _resp(True, "Password reset")
 


### PR DESCRIPTION
Title. 

The current implementation doesn't seem to rotate the API key on password reset, which is a security issue.
Also, I've changed the /auth/login api so that it returns the API key within the JSON body too.

This is untested code, please make sure it works before merging.

Thanks!