### PR TITLE
Stop murdering query parameters

### DIFF
--- a/daemons/beryllium/nginx.template.cfg
+++ b/daemons/beryllium/nginx.template.cfg
@@ -42,7 +42,7 @@ http {
 	    proxy_set_header X-Real-IP $remote_addr;
 	    proxy_set_header X-Forwared-For $proxy_add_x_forwarded_for;
 	    proxy_buffering off;
-	    proxy_pass http://$upstream$uri;       
+	    proxy_pass http://$upstream$request_uri;       
     }    
   }
 }

--- a/daemons/beryllium/nginx.template.cfg
+++ b/daemons/beryllium/nginx.template.cfg
@@ -15,7 +15,8 @@ stream {
   }   
  
   server {
-    listen 443; 
+    listen 443;
+    listen [::]:443;
         
     proxy_connect_timeout 1s;
     proxy_timeout 3s;
@@ -35,6 +36,7 @@ http {
 
   server {
     listen 80; 
+    listen [::]:80;
     server_name _;
     location / {
 	    proxy_redirect off;


### PR DESCRIPTION
Update `$uri` to `$request_uri`. 

See http://nginx.org/en/docs/http/ngx_http_core_module.html#var_request_uri